### PR TITLE
[Fix] Missing r in requirements at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ y luego actiar el ambiente virtual:
 `$ source env/bin/activate`
 
 Una vez en el ambiente, hay que instalar los requerimientos
-`$ pip install requirments.txt`
+`$ pip install requirements.txt`
 
 Estás listo para usar Ducky!
 


### PR DESCRIPTION
### Descripcion del problema
Faltaba una 'r' en la documentación

### Descripcion de la solución
Se agregó

### Checklist

- [ ] Resuelve el issue #
- [x] Pasaron las pruebas
- [x] Se actualizó la documentación

## Notas Adicionales